### PR TITLE
feedが生成されるはずの場所を参照するように変更

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -144,13 +144,13 @@ widgets:
             #     url: 'https://facebook.com'
             Twitter:
                 icon: fab fa-twitter
-                url: 'https://twitter.com/techbookfest'
+                url: 'https://x.com/techbookfest'
             # Dribbble:
             #     icon: fab fa-dribbble
             #     url: 'https://dribbble.com'
             RSS:
                 icon: fas fa-rss
-                url: /
+                url: /atom.xml
     -
         # Widget name
         type: toc


### PR DESCRIPTION
https://github.com/ppoffice/hexo-theme-icarus/pull/1341
うっかり本家に間違えて一回PR送っちゃった…

TwitterのリンクのアイコンがTwitterのままなのはいったん気にしない…(fontawesomeのアップデートとか色々必要そうなので